### PR TITLE
[Part 2] Improve RayActorDeadError: Support RayErrorInfo as a error payload

### DIFF
--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -25,8 +25,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
               (override));
   MOCK_METHOD(bool, FailOrRetryPendingTask,
               (const TaskID &task_id, rpc::ErrorType error_type, const Status *status,
-               const rpc::RayException *creation_task_exception,
-               bool mark_task_object_failed),
+               const rpc::RayErrorInfo *ray_error_info, bool mark_task_object_failed),
               (override));
   MOCK_METHOD(void, OnTaskDependenciesInlined,
               (const std::vector<ObjectID> &inlined_dependency_ids,
@@ -35,7 +34,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
   MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id), (override));
   MOCK_METHOD(void, MarkPendingTaskObjectFailed,
               (const TaskSpecification &spec, rpc::ErrorType error_type,
-               const rpc::RayException *creation_task_exception),
+               const rpc::RayErrorInfo *ray_error_info),
               (override));
   MOCK_METHOD(absl::optional<TaskSpecification>, GetTaskSpec, (const TaskID &task_id),
               (const, override));

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -122,7 +122,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool FailOrRetryPendingTask(const TaskID &task_id, rpc::ErrorType error_type,
                               const Status *status,
-                              const rpc::RayException *creation_task_exception = nullptr,
+                              const rpc::RayErrorInfo *ray_error_info = nullptr,
                               bool mark_task_object_failed = true) override {
     num_tasks_failed++;
     return true;
@@ -136,7 +136,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   void MarkPendingTaskObjectFailed(
       const TaskSpecification &spec, rpc::ErrorType error_type,
-      const rpc::RayException *creation_task_exception = nullptr) override {}
+      const rpc::RayErrorInfo *ray_error_info = nullptr) override {}
 
   bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
 

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -554,7 +554,7 @@ void CoreWorkerDirectTaskSubmitter::RequestNewWorkerIfNeeded(
             while (!task_queue.empty()) {
               auto &task_spec = task_queue.front();
               RAY_UNUSED(task_finisher_->MarkPendingTaskObjectFailed(
-                  task_spec, rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED, nullptr));
+                  task_spec, rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED));
               task_queue.pop_front();
             }
             if (scheduling_key_entry.CanDelete()) {

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -151,6 +151,24 @@ inline const std::string &GetDeathCauseString(const rpc::ActorDeathCause *death_
   return death_cause_string.at(death_cause_case);
 }
 
+/// Get the error information from the actor death cause.
+/// \param[in] death_cause The rpc message that contains the actos death information.
+/// \return RayErrorInfo that has propagated death cause. Nullptr if not sufficient
+/// information is provided.
+inline std::unique_ptr<rpc::RayErrorInfo> GetErrorInfoFromActorDeathCause(
+    const rpc::ActorDeathCause *death_cause) {
+  auto creation_task_exception = GetCreationTaskExceptionFromDeathCause(death_cause);
+  if (creation_task_exception == nullptr) {
+    return nullptr;
+  }
+  auto error_info = std::make_unique<rpc::RayErrorInfo>();
+  if (creation_task_exception != nullptr) {
+    // Shouldn't use Swap here because we don't own the pointer.
+    error_info->mutable_actor_init_failure()->CopyFrom(*creation_task_exception);
+  }
+  return error_info;
+}
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -146,6 +146,14 @@ enum ErrorType {
   OBJECT_UNRECONSTRUCTABLE_LINEAGE_EVICTED = 13;
 }
 
+/// The information per ray error type.
+message RayErrorInfo {
+  oneof error {
+    RayException actor_init_failure = 1;
+    RayActorDiedError actor_died = 2;
+  }
+}
+
 /// The task exception encapsulates all information about task
 /// execution execeptions.
 message RayException {
@@ -155,6 +163,19 @@ message RayException {
   bytes serialized_exception = 2;
   // The formatted exception string.
   string formatted_exception_string = 3;
+}
+
+message RayActorDiedError {
+  // The address of the the actor.
+  Address address = 1;
+  // Name of the actor.
+  string name = 2;
+  // The process id of this actor.
+  uint32 pid = 3;
+  // The class name of the dead actor.
+  string class_name = 4;
+  // The error message of the dead actor error.
+  string error_message = 5;
 }
 
 /// The runtime environment describes all the runtime packages needed to

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -155,7 +155,7 @@ message ActorTableData {
   Address owner_address = 10;
   // Whether the actor is persistent.
   bool is_detached = 11;
-  // Name of the actor. Only populated if is_detached is true.
+  // Name of the actor.
   string name = 12;
   // Last timestamp that the actor state was updated.
   double timestamp = 13;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
